### PR TITLE
Skip this test if JSON::XS is not installed

### DIFF
--- a/t/004_json.t
+++ b/t/004_json.t
@@ -1,6 +1,7 @@
 use strict;
 use utf8;
 use Test::More;
+use Test::Requires 'JSON::XS';
 
 use Test::RedisServer;
 use Cache::Redis;


### PR DESCRIPTION
JSON::XS is not a required module.

The test is failed if JSON::XS is not installed with original code.